### PR TITLE
WIP: conditionally read Option<T>

### DIFF
--- a/bin-proto-derive/src/attr.rs
+++ b/bin-proto-derive/src/attr.rs
@@ -11,6 +11,7 @@ pub struct Attrs {
     pub bits: Option<u32>,
     pub flexible_array_member: bool,
     pub length: Option<syn::Expr>,
+    pub condition: Option<syn::Expr>,
 }
 
 impl Attrs {
@@ -48,6 +49,9 @@ impl Attrs {
         if self.length.is_some() {
             return Err(Error::new(span, "unexpected length attribute for enum"));
         }
+        if self.condition.is_some() {
+            return Err(Error::new(span, "unexpected condition attribute for enum"));
+        }
         Ok(())
     }
 
@@ -84,6 +88,9 @@ impl Attrs {
         }
         if self.length.is_some() {
             return Err(Error::new(span, "unexpected length attribute for variant"));
+        }
+        if self.condition.is_some() {
+            return Err(Error::new(span, "unexpected condition attribute for variant"));
         }
         Ok(())
     }
@@ -180,6 +187,9 @@ impl TryFrom<&[syn::Attribute]> for Attrs {
                             }
                             "length" => {
                                 attribs.length = Some(meta_name_value_to_parse(name_value)?)
+                            }
+                            "condition" => {
+                                attribs.condition = Some(meta_name_value_to_parse(name_value)?)
                             }
                             _ => {
                                 return Err(Error::new(meta_list.span(), "unrecognised attribute"))

--- a/bin-proto/src/conditional.rs
+++ b/bin-proto/src/conditional.rs
@@ -1,0 +1,54 @@
+//! Utilities for conditional fields
+
+use crate::{BitRead, BitWrite, ByteOrder, Error};
+
+/// A trait for Option types that are read/written conditionally.
+pub trait Conditional<Ctx = ()>: Sized {
+    fn read(
+        read: &mut dyn BitRead,
+        byte_order: ByteOrder,
+        ctx: &mut Ctx,
+        condition: bool,
+    ) -> Result<Self, Error>;
+
+    fn write(
+        &self,
+        write: &mut dyn BitWrite,
+        byte_order: ByteOrder,
+        ctx: &mut Ctx,
+    ) -> Result<(), Error>;
+}
+
+#[cfg(test)]
+macro_rules! test_conditional {
+    ($t:ty => [$bytes:expr, $value:expr]) => {
+        #[test]
+        fn read_conditional() {
+            let bytes: &[u8] = $bytes.as_slice();
+            assert_eq!(
+                <$t as crate::Conditional>::read(
+                    &mut bitstream_io::BitReader::endian(bytes, bitstream_io::BigEndian),
+                    crate::ByteOrder::BigEndian,
+                    &mut (),
+                    $value.len()
+                )
+                .unwrap(),
+                $value
+            )
+        }
+
+        #[test]
+        fn write_conditional() {
+            let mut buffer: Vec<u8> = Vec::new();
+            let value: $t = $value;
+            crate::Conditional::write(
+                &value,
+                &mut bitstream_io::BitWriter::endian(&mut buffer, bitstream_io::BigEndian),
+                crate::ByteOrder::BigEndian,
+                &mut (),
+            )
+            .unwrap();
+            assert_eq!(buffer.as_slice(), $bytes)
+        }
+    };
+}

--- a/bin-proto/src/lib.rs
+++ b/bin-proto/src/lib.rs
@@ -56,6 +56,7 @@ pub use self::bit_write::BitWrite;
 pub use self::byte_order::ByteOrder;
 pub use self::error::{Error, Result};
 pub use self::externally_length_prefixed::ExternallyLengthPrefixed;
+pub use self::conditional::Conditional;
 pub use self::flexible_array_member::FlexibleArrayMember;
 pub use self::protocol::Protocol;
 pub use self::protocol::ProtocolNoCtx;
@@ -258,6 +259,7 @@ mod bit_read;
 mod bit_write;
 #[macro_use]
 mod externally_length_prefixed;
+mod conditional;
 mod byte_order;
 mod flexible_array_member;
 mod types;

--- a/bin-proto/tests/conditional.rs
+++ b/bin-proto/tests/conditional.rs
@@ -1,0 +1,49 @@
+use bin_proto::{ByteOrder, Protocol, ProtocolNoCtx};
+
+#[derive(Protocol, Debug, PartialEq, Eq)]
+pub struct Prefix {
+    pub reason_length: u8,
+}
+
+#[derive(Protocol, Debug, PartialEq, Eq)]
+pub struct WithCondition {
+    pub foo: u32,
+    #[protocol(condition = "foo > 3")]
+    pub data: Option<u32>,
+}
+
+
+
+#[test]
+fn can_read_conditional_element_true() {
+    assert_eq!(
+        WithCondition {
+            foo: 5,
+            data: Some(3u32),
+        },
+        WithCondition::from_bytes(
+            &[
+                0, 0, 0, 5, // conditional
+                0, 0, 0, 3 // 3
+            ],
+            ByteOrder::BigEndian,
+        )
+        .unwrap()
+    );
+}
+#[test]
+fn can_read_conditional_element_false() {
+    assert_eq!(
+        WithCondition {
+            foo: 2,
+            data: None,
+        },
+        WithCondition::from_bytes(
+            &[
+                0, 0, 0, 2, // conditional
+            ],
+            ByteOrder::BigEndian,
+        )
+        .unwrap()
+    );
+}

--- a/bin-proto/tests/lib.rs
+++ b/bin-proto/tests/lib.rs
@@ -12,3 +12,5 @@ mod ipv4;
 mod length_prefix;
 #[cfg(test)]
 mod structs;
+#[cfg(test)]
+mod conditional;


### PR DESCRIPTION
So, I really like the readability of bin-proto's internals. But feature-wise, it's not where I'd need it to be to replace deku.

For one, I'd like the ability to conditionally read an Option<T>, based on an external field. Kinda like externally length prefixed, but for Option.

I started making it, but I quickly realized that, in order for it to be compatible with other attributes, like `bits`, it start's getting somewhat complicated. And from what I can tell, with the current infrastructure, I'd need a trait `Conditional` and `ConditionalWithBitfield` or something alike? That feels somewhat clunky.

I guess it can be easily solved using the new Ctx system, but I'd like for it to be a first-class citizen.

What's your opinion on this?